### PR TITLE
Unset the suite at the end of the hooks run

### DIFF
--- a/src/cth_readable_shell.erl
+++ b/src/cth_readable_shell.erl
@@ -65,7 +65,7 @@ pre_end_per_suite(_Suite,Config,State) ->
 
 %% @doc Called after end_per_suite.
 post_end_per_suite(_Suite,_Config,Return,State) ->
-    {Return, State}.
+    {Return, State#state{suite=undefined}}.
 
 %% @doc Called before each init_per_group.
 pre_init_per_group(_Group,Config,State) ->


### PR DESCRIPTION
Partially addresses issue #10 -- when a suite is skipped through
configuration, the `pre_init_per_suite/3` hook is not called, and the
suite name is not ever set.

This ends up mis-reporting the previous suite instead of the current
(undefined through the hook system) one. There is no complete fix
available without modifying common test itself.

This patch instead unsets the suite at the end of a run so that skipped
suites are reported as 'undefined' rather than reporting the wrong suite
entirely.

CC @sirihansen