### PR TITLE
Add support for on_tc_skip/4

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ configurations.
 
 ## Changelog
 
+1.2.5:
+- support for `on_tc_skip/4` to fully prevent misreporting of skipped suites
+
 1.2.4:
 - unset suite name at the end of hooks run to prevent misreporting
 

--- a/src/cth_readable.app.src
+++ b/src/cth_readable.app.src
@@ -1,6 +1,6 @@
 {application, cth_readable,
  [{description, "Common Test hooks for more readable logs"},
-  {vsn, "1.2.4"},
+  {vsn, "1.2.5"},
   {registered, [cth_readable_failonly]},
   {applications,
    [kernel,

--- a/src/cth_readable_failonly.erl
+++ b/src/cth_readable_failonly.erl
@@ -25,7 +25,7 @@
 -export([post_end_per_testcase/4]).
 
 -export([on_tc_fail/3]).
--export([on_tc_skip/3]).
+-export([on_tc_skip/3, on_tc_skip/4]).
 
 -export([terminate/1]).
 
@@ -128,7 +128,16 @@ on_tc_fail(_TC, _Reason, State=#state{}) ->
     State.
 
 %% @doc Called when a test case is skipped by either user action
-%% or due to an init function failing.
+%% or due to an init function failing (>= 19.3)
+on_tc_skip(_Suite, {_TC,_Group}, _Reason, State=#state{}) ->
+    call_handlers(flush, State#state.handlers),
+    State;
+on_tc_skip(_Suite, _TC, _Reason, State=#state{}) ->
+    call_handlers(flush, State#state.handlers),
+    State.
+
+%% @doc Called when a test case is skipped by either user action
+%% or due to an init function failing (pre 19.3)
 on_tc_skip({_TC,_Group}, _Reason, State=#state{}) ->
     call_handlers(flush, State#state.handlers),
     State;

--- a/src/cth_readable_nosasl.erl
+++ b/src/cth_readable_nosasl.erl
@@ -18,7 +18,7 @@
 -export([post_end_per_testcase/4]).
 
 -export([on_tc_fail/3]).
--export([on_tc_skip/3]).
+-export([on_tc_skip/3, on_tc_skip/4]).
 
 -export([terminate/1]).
 
@@ -80,7 +80,11 @@ on_tc_fail(_TC, _Reason, State) ->
     State.
 
 %% @doc Called when a test case is skipped by either user action
-%% or due to an init function failing.
+%% or due to an init function failing. (>= 19.3)
+on_tc_skip(_Suite, _TC, _Reason, State) ->
+    State.
+%% @doc Called when a test case is skipped by either user action
+%% or due to an init function failing. (Pre-19.3)
 on_tc_skip(_TC, _Reason, State) ->
     State.
 

--- a/src/cth_readable_shell.erl
+++ b/src/cth_readable_shell.erl
@@ -36,7 +36,7 @@
 -export([post_end_per_testcase/4]).
 
 -export([on_tc_fail/3]).
--export([on_tc_skip/3]).
+-export([on_tc_skip/3, on_tc_skip/4]).
 
 -export([terminate/1]).
 
@@ -104,7 +104,16 @@ on_tc_fail(TC, Reason, State=#state{suite=Suite}) ->
     State.
 
 %% @doc Called when a test case is skipped by either user action
-%% or due to an init function failing.
+%% or due to an init function failing. (>= 19.3)
+on_tc_skip(Suite, {TC,Group}, Reason, State=#state{}) ->
+    ?SKIP(Suite, "~p (group ~p)", [TC, Group], Reason),
+    State#state{suite=Suite};
+on_tc_skip(Suite, TC, Reason, State=#state{}) ->
+    ?SKIP(Suite, "~p", [TC], Reason),
+    State#state{suite=Suite}.
+
+%% @doc Called when a test case is skipped by either user action
+%% or due to an init function failing. (Pre-19.3)
 on_tc_skip({TC,Group}, Reason, State=#state{suite=Suite}) ->
     ?SKIP(Suite, "~p (group ~p)", [TC, Group], Reason),
     State;


### PR DESCRIPTION
This allows to properly report the right suites being skipped
on OTP >= 19.3

Should fix #10 
CC @sirihansen -- if this looks good to you I'll go publish this and patch up rebar3