### PR TITLE
report end_per_testcase errors (non-critical)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ configurations.
 
 ## Changelog
 
+1.2.6:
+- report `end_per_testcase` errors as a non-critical failure when the test case passes
+- add in a (voluntarily failing) test suite to demo multiple output cases required
+
 1.2.5:
 - support for `on_tc_skip/4` to fully prevent misreporting of skipped suites
 

--- a/src/cth_readable.app.src
+++ b/src/cth_readable.app.src
@@ -1,6 +1,6 @@
 {application, cth_readable,
  [{description, "Common Test hooks for more readable logs"},
-  {vsn, "1.2.5"},
+  {vsn, "1.2.6"},
   {registered, [cth_readable_failonly]},
   {applications,
    [kernel,

--- a/src/cth_readable_shell.erl
+++ b/src/cth_readable_shell.erl
@@ -91,7 +91,15 @@ pre_init_per_testcase(_TC,Config,State) ->
 post_end_per_testcase(TC,_Config,ok,State=#state{suite=Suite}) ->
     ?OK(Suite, "~p", [TC]),
     {ok, State};
-post_end_per_testcase(_TC,_Config,Error,State) ->
+post_end_per_testcase(TC,Config,Error,State=#state{suite=Suite}) ->
+    case lists:keyfind(tc_status, 1, Config) of
+        {tc_status, ok} ->
+            %% Test case passed, but we still ended in an error
+            ?STACK(Suite, "~p", [TC], Error, ?SKIPC, "end_per_testcase FAILED");
+        _ ->
+            %% Test case failed, in which case on_tc_fail already reports it
+            ok
+    end,
     {Error, State}.
 
 %% @doc Called after post_init_per_suite, post_end_per_suite, post_init_per_group,

--- a/test/sample_SUITE.erl
+++ b/test/sample_SUITE.erl
@@ -1,0 +1,36 @@
+-module(sample_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+
+init_per_suite(Config) ->
+  Config.
+
+end_per_suite(_Config) ->
+  ok.
+
+init_per_group(_GroupName, Config) ->
+  Config.
+
+end_per_group(_GroupName, _Config) ->
+  ok.
+
+init_per_testcase(_TestCase, Config) ->
+  Config.
+
+end_per_testcase(_TestCase, _Config) ->
+  ok = application:stop(foo),
+  ok.
+
+groups() ->
+  [].
+
+all() ->
+  [my_test_case].
+
+my_test_case() ->
+  [].
+
+my_test_case(_Config) ->
+  ok.

--- a/test/show_logs_SUITE.erl
+++ b/test/show_logs_SUITE.erl
@@ -1,0 +1,49 @@
+-module(show_logs_SUITE).
+-compile(export_all).
+-include_lib("common_test/include/ct.hrl").
+
+all() -> [{group, works}, {group, fails}, skip].
+
+groups() ->
+    [{all, [], [error_logger, sasl, ctpal]},
+     {works, [], [{group, all}]},
+     {fails, [], [{group, all}]}].
+
+init_per_group(fails, Config) ->
+    [{fail, true} | Config];
+init_per_group(works, Config) ->
+    [{fail, false} | Config];
+init_per_group(all, Config) ->
+    Config.
+
+end_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(skip, _Config) ->
+    {skip, manual};
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, Config) ->
+    Config.
+
+error_logger(Config) ->
+    error_logger:error_msg("error\n"),
+    error_logger:warning_msg("warn\n"),
+    error_logger:info_msg("info\n"),
+    ?config(fail, Config) andalso error(fail).
+
+sasl(Config) ->
+    application:start(sasl),
+    application:start(tools),
+    %ct:pal("~p~n",[sys:get_state(error_logger)]),
+    application:stop(tools),
+    application:stop(sasl),
+    ?config(fail, Config) andalso error(fail).
+
+ctpal(Config) ->
+    ct:pal("ct:pal call"),
+    ?config(fail, Config) andalso error(fail).
+
+skip(_Config) ->
+    ok.


### PR DESCRIPTION
Also commit the always failing test suite used to check at output for
the hooks.

And bump to 1.2.6 while we're at it.