### PR TITLE
Support OTP21-RC1

### DIFF
--- a/src/cth_readable_failonly.erl
+++ b/src/cth_readable_failonly.erl
@@ -62,6 +62,7 @@ init(Id, _Opts) ->
     error_logger:tty(false), % TODO check if on to begin with
     application:load(sasl), % TODO do this optionally?
     LagerReset = setup_lager(),
+    ok = error_logger:start(),
     case application:get_env(sasl, sasl_error_logger) of
         {ok, tty} ->
             ok = gen_event:add_handler(error_logger, ?MODULE, [sasl]),


### PR DESCRIPTION
Hi, @ferd 

I confirmed that the [my project](https://github.com/soranoba/bbmustache/tree/otp21) can build with OTP21-RC1, but I encountered a problem that `rebar3 ct` does not work properly.

```
*** CT 2018-05-04 21:00:18.548 *** Suite Hook
Failed to start a CTH: exit:{noproc,
                             [{gen,do_for_proc,2,
                               [{file,"gen.erl"},{line,228}]},
                              {gen_event,rpc,2,
                               [{file,"gen_event.erl"},{line,239}]},
                              {cth_readable_failonly,init,2,
                               [{file,
                                 "/home/tristan/Devel/rebar3/_build/default/lib/cth_readable/src/cth_readable_failonly.erl"},
                                {line,72}]},
                              {ct_hooks,call_init,3,
                               [{file,"ct_hooks.erl"},{line,167}]},
                              {ct_hooks,call,4,
                               [{file,"ct_hooks.erl"},{line,247}]},
                              {ct_hooks,call,4,
                               [{file,"ct_hooks.erl"},{line,250}]},
                              {ct_hooks,call,4,
                               [{file,"ct_hooks.erl"},{line,235}]},
                              {ct_util,do_start,4,
                               [{file,"ct_util.erl"},{line,204}]}]}
```

I checked it, it occurring because error_logger process does not exist.

This PR is making interim fixes.
Since error_logger seems to be deprecated in the future, I seems to it may be necessary to follow the latest API.
http://erlang.org/documentation/doc-10.0-rc1/lib/kernel-6.0/doc/html/error_logger.html

Thanks.