### PR TITLE
Prevent crashes when Lager removes default logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ configurations.
 
 ## Changelog
 
+1.4.4:
+- Better interactions with Lager; since newer releases, it removes the Logger default interface when starting, which could cause crashes when this happened before the CT hooks would start (i.e. a eunit suite)
+
 1.4.3:
 - OTP-21.2 support (Logger interface); importing a function that was de-exported by OTP team
 

--- a/rebar.config
+++ b/rebar.config
@@ -7,5 +7,14 @@
 {ct_compile_opts, [
     {parse_transform, cth_readable_transform}
 ]}.
+{eunit_compile_opts, [ % to avoid 'do eunit, ct' eating up the parse transform
+    {parse_transform, cth_readable_transform}
+]}.
 
 {erl_opts, [{platform_define, "^(R|1|20)", no_logger_hrl}]}.
+
+{profiles, [
+    {test, [
+        {deps, [{lager, "3.6.10"}]}
+    ]}
+]}.

--- a/src/cth_readable.app.src
+++ b/src/cth_readable.app.src
@@ -1,6 +1,6 @@
 {application, cth_readable,
  [{description, "Common Test hooks for more readable logs"},
-  {vsn, "1.4.3"},
+  {vsn, "1.4.4"},
   {registered, [cth_readable_failonly, cth_readable_logger]},
   {applications,
    [kernel,

--- a/src/cth_readable_failonly.erl
+++ b/src/cth_readable_failonly.erl
@@ -85,7 +85,7 @@ init(Id, _Opts) ->
     %% hook and then CT as a whole.
     Named = spawn_link(fun() -> receive after infinity -> ok end end),
     register(?MODULE, Named),
-    HasLogger = has_logger(), % Pre OTP-21 or not, and with safe config
+    HasLogger = has_logger(), % Pre OTP-21 or not
     Cfg = maybe_steal_logger_config(),
     case HasLogger of
         false ->

--- a/test/log_tests.erl
+++ b/test/log_tests.erl
@@ -1,0 +1,9 @@
+-module(log_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% run this to check interactions between lager and logger
+%% by calling `rebar3 do eunit, ct'
+start_test() ->
+    {ok, Apps} = application:ensure_all_started(lager),
+    io:format(user, "~p~n", [logger:get_handler_config()]),
+    [application:stop(App) || App <- Apps].


### PR DESCRIPTION
This is done by returning the right type in the right circumstances.