### PR TITLE
Fixing Lager in a post-logger world

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ configurations.
 
 ## Changelog
 
+1.4.5:
+- Restoring proper logs for Lager in OTP-21+. A problem existed when `error_logger` was no longer registered by default and lager log lines would silently get lost.
+
 1.4.4:
 - Better interactions with Lager; since newer releases, it removes the Logger default interface when starting, which could cause crashes when this happened before the CT hooks would start (i.e. a eunit suite)
 

--- a/src/cth_readable.app.src
+++ b/src/cth_readable.app.src
@@ -1,6 +1,6 @@
 {application, cth_readable,
  [{description, "Common Test hooks for more readable logs"},
-  {vsn, "1.4.4"},
+  {vsn, "1.4.5"},
   {registered, [cth_readable_failonly, cth_readable_logger]},
   {applications,
    [kernel,

--- a/src/cth_readable_lager_backend.erl
+++ b/src/cth_readable_lager_backend.erl
@@ -113,7 +113,11 @@ handle_event({log, Message},
             %% everything deadlock, so we gotta go async on the logging call.
             %% We also need to do a call so that lager doesn't reforward the
             %% event in an infinite loop.
-            spawn(fun() -> gen_event:call(error_logger, cth_readable_failonly, {lager, Formatted}) end),
+            Name = case erlang:function_exported(logger, module_info, 0) of
+                true -> cth_readable_logger;
+                false -> error_logger
+            end,
+            spawn(fun() -> gen_event:call(Name, cth_readable_failonly, {lager, Formatted}) end),
             ct_logs:tc_log(default, Formatted, []),
             {ok, State};
         false ->


### PR DESCRIPTION
Essentially, back when logger was added, patches were put in cthr.erl to
dynamically dispatch between error_logger and the logger handler.

The fake lager backend used by this library had a similar mechanism to
work around locking issues in filtering and forwarding, but was never
updated. So when 'error_logger' stopped being used by default and always
present, lager's log messages got silently dropped.

This patch brings back the same dynamic dispatch logic that is used in
cthr to allow the fake lager log to be properly forwarded. A test case
has been added to prevent further regressions.