### PR TITLE
support assertNot failure case in maybe_eunit_format

### DIFF
--- a/src/cth_readable_helpers.erl
+++ b/src/cth_readable_helpers.erl
@@ -29,11 +29,11 @@ maybe_eunit_format({{Type, Props}, _}) when Type =:= assert_failed
     if
         HasEUnitProps ->
             [io_lib:format("~nFailure/Error: ?assert(~s)~n", [proplists:get_value(expression, Props)]),
-             io_lib:format("  expected: true~n", []),
+             io_lib:format("  expected: ~p~n", [proplists:get_value(expected, Props)]),
              case proplists:get_value(value, Props) of
-                 false ->
-                     io_lib:format("       got: false~n", []);
                  {not_a_boolean, V} ->
+                     io_lib:format("       got: ~p~n", [V]);
+                 V ->
                      io_lib:format("       got: ~p~n", [V])
              end, io_lib:format("      line: ~p", [proplists:get_value(line, Props)])];
         HasHamcrestProps ->


### PR DESCRIPTION
If the failure is from ?assertNot being 'true' then the old
maybe_eunit_format would fail because it only matches on the
value being 'false'. This change fixes it to print any value.