### PR TITLE
make the buffer in cth_readable_failonly optionaly bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ There are currently the following hooks:
    shell in case of failures. It also provides `cthr:pal/1-4` functions,
    working like `ct:pal/1-4`, but being silenceable by that hook. A parse
    transform exists to automatically convert `ct:pal/1-3` into `cthr:pal/1-3`.
-   Also automatically handles lager.
+   Also automatically handles lager. This hook buffers the IO/logging events,
+   and the buffer size can be limited with the `mmax_events` config option. The
+   default value is `inf` which means that all events are buffered.
 4. `cth_readable_nosasl`, which disables all SASL logging. It however requires
    to be run *before* `cth_readable_failonly` to work.
 
@@ -35,7 +37,7 @@ Add the following to your `rebar.config`:
     {cth_readable, {git, "https://github.com/ferd/cth_readable.git", {tag, "v1.1.0"}}}
     ]}.
 
-{ct_opts, [{ct_hooks, [cth_readable_failonly, cth_readable_shell]}]}.
+{ct_opts, [{ct_hooks, [{cth_readable_failonly, [{max_events, 1000}]}, cth_readable_shell]}]}.
 {ct_compile_opts, [{parse_transform, cth_readable_transform}]}.
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are currently the following hooks:
    working like `ct:pal/1-4`, but being silenceable by that hook. A parse
    transform exists to automatically convert `ct:pal/1-3` into `cthr:pal/1-3`.
    Also automatically handles lager. This hook buffers the IO/logging events,
-   and the buffer size can be limited with the `mmax_events` config option. The
+   and the buffer size can be limited with the `max_events` config option. The
    default value is `inf` which means that all events are buffered.
 4. `cth_readable_nosasl`, which disables all SASL logging. It however requires
    to be run *before* `cth_readable_failonly` to work.

--- a/test/failonly_SUITE.erl
+++ b/test/failonly_SUITE.erl
@@ -1,0 +1,18 @@
+-module(failonly_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+
+
+all() ->
+  [pal].
+
+%% run with rebar3 ct --readable false
+%% and configure rebar.config with
+%%     {ct_opts, [
+%        {ct_hooks, [{cth_readable_failonly, [{max_events, 2}]}, cth_readable_shell]}
+%      ]}.
+pal() ->
+  [ct:pal("Event ~p", [X]) || X <- lists:seq(0, 10)],
+  error(crash).


### PR DESCRIPTION
This addresses the issue found in #33

changes:
- config parameter for maximum amount of buffered events
- default to inf, which is buffer all (current behavior)
- change buffer to queue to handle in/out in O(1)
- streamline internal config to make adding the extra config parameter easier