### PR TITLE
remove catch all in handle_event

### DIFF
--- a/src/cth_readable_failonly.erl
+++ b/src/cth_readable_failonly.erl
@@ -236,9 +236,7 @@ handle_event(Event, State) ->
         sasl -> buffer_event({sasl, {calendar:local_time(), Event}}, State);
         error_logger -> buffer_event({error_logger, {erlang:universaltime(), Event}}, State)
     end,
-    {ok, NewState};
-handle_event(_, S) ->
-    {ok, S}.
+    {ok, NewState}.
 
 handle_info(_, State) ->
     {ok, State}.


### PR DESCRIPTION
this slipped in last time, should we also add a 
```
-behavior(gen_event).
```
