### PR TITLE
Use the documented API for io:format()

### DIFF
--- a/src/cth_readable_compact_shell.erl
+++ b/src/cth_readable_compact_shell.erl
@@ -14,12 +14,12 @@
 -define(STACK(Suite, CasePat, CaseArgs, Reason, Color, Label),
         begin
          ?CASE(Suite, CasePat, Color, Label, CaseArgs),
-         io:format(user, "%%% ~p ==> "++colorize(Color, maybe_eunit_format(Reason))++"~n", [Suite])
+         io:format(user, "%%% ~p ==> ~ts~n", [Suite,colorize(Color, maybe_eunit_format(Reason))])
         end).
 -define(CASE(Suite, CasePat, Color, Res, Args),
         case Res of
-            "OK" -> io:format(user, colorize(Color, "."), []);
-            _ -> io:format(user, "~n%%% ~p ==> "++CasePat++": "++colorize(Color, Res)++"~n", [Suite | Args])
+            "OK" -> io:put_chars(user, colorize(Color, "."));
+            _ -> io:format(user, lists:flatten(["~n%%% ~p ==> ",CasePat,": ",colorize(Color, Res),"~n"]), [Suite | Args])
         end).
 
 %% Callbacks

--- a/src/cth_readable_shell.erl
+++ b/src/cth_readable_shell.erl
@@ -14,10 +14,13 @@
 -define(STACK(Suite, CasePat, CaseArgs, Reason, Color, Label),
         begin
          ?CASE(Suite, CasePat, Color, Label, CaseArgs),
-         io:format(user, "%%% ~p ==> "++colorize(Color, maybe_eunit_format(Reason))++"~n", [Suite])
+         io:format(user, "%%% ~p ==> ~ts~n", [Suite,colorize(Color, maybe_eunit_format(Reason))])
         end).
 -define(CASE(Suite, CasePat, Color, Res, Args),
-        io:format(user, "%%% ~p ==> "++CasePat++": "++colorize(Color, Res)++"~n", [Suite | Args])).
+        case Res of
+            "OK" -> io:put_chars(user, colorize(Color, "."));
+            _ -> io:format(user, lists:flatten(["~n%%% ~p ==> ",CasePat,": ",colorize(Color, Res),"~n"]), [Suite | Args])
+        end).
 
 %% Callbacks
 -export([id/1]).


### PR DESCRIPTION
The `io:format()` functions are not documented to support deep lists
as format strings.

Update the `io:format()` calls in this library to only use flat format
strings.

Reason for this change:

- To help the OTP team to keep deep format strings out of the OTP code
  base. In the daily builds between releases, we include a modified
  version of `io:format()` that will crash for deep format strings.
  Without the change in this commit, test cases for `egd`, `percept`,
  `eplot`, and `rebar3_otp_install_plugin` will all fail because they
  use `rebar3 ct`, which in turn calls this library.

- To future proof this library in case deep format strings will be
  rejected in a future release of OTP.