### PR TITLE
Port learnings from usage in `rebar3`'s `_checkouts` for testing

### DIFF
--- a/src/cth_readable_shell.erl
+++ b/src/cth_readable_shell.erl
@@ -18,7 +18,7 @@
           case Verbose of
             true ->
               ?CASE(Suite, CasePat, Color, Label, CaseArgs),
-             io:format(user, "%%% ~p ==> ~ts~n", [Suite,colorize(Color, maybe_eunit_format(Reason))]);
+             io:format(user, "~n%%% ~p ==> ~ts~n", [Suite,colorize(Color, maybe_eunit_format(Reason))]);
             false ->
               io:format(user, colorize(Color, "*"), [])
           end
@@ -26,7 +26,7 @@
 -define(CASE(Suite, CasePat, Color, Res, Args),
         case Res of
             "OK" -> io:put_chars(user, colorize(Color, "."));
-            _ -> io:format(user, lists:flatten(["~n%%% ~p ==> ",CasePat,": ",colorize(Color, Res),"~n"]), [Suite | Args])
+            _ -> io:format(user, lists:flatten(["%%% ~p ==> ",CasePat,": ",colorize(Color, Res)]), [Suite | Args])
         end).
 
 %% Callbacks
@@ -51,7 +51,7 @@
 
 -export([terminate/1]).
 
--record(state, {id, suite, groups, opts}).
+-record(state, {id, suite, groups, opts, last_suite, last_tc_failed}).
 
 %% @doc Return a unique id for this CTH.
 id(_Opts) ->
@@ -60,22 +60,44 @@ id(_Opts) ->
 %% @doc Always called before any other callback function. Use this to initiate
 %% any common state.
 init(Id, Opts) ->
-    {ok, #state{id=Id, opts=Opts}}.
+    {ok, #state{id=Id, opts=Opts, last_suite=undefined, last_tc_failed=false}}.
 
 %% @doc Called before init_per_suite is called.
 pre_init_per_suite(Suite,Config,State) ->
+    io:format(user, "%%% ~p", [Suite]),
     {Config, State#state{suite=Suite, groups=[]}}.
 
 %% @doc Called after init_per_suite.
-post_init_per_suite(_Suite,_Config,Return,State) ->
-    {Return, State}.
+post_init_per_suite(_Suite,_Config,Return,State=#state{opts=Opts}) ->
+    IsVerbose = is_verbose(Opts),
+    SuiteSkipped
+        = case {IsVerbose, Return} of
+              {true, {skip, _}} ->
+                  io:format(user, " ==> ", []),
+                  true;
+              {false, {skip, _}} ->
+                  io:format(user, ": ", []),
+                  true;
+              _Other ->
+                  false
+          end,
+    {Return, State#state{last_tc_failed=SuiteSkipped}}.
 
 %% @doc Called before end_per_suite.
 pre_end_per_suite(_Suite,Config,State) ->
     {Config, State}.
 
 %% @doc Called after end_per_suite.
-post_end_per_suite(_Suite,_Config,Return,State) ->
+post_end_per_suite(_Suite,_Config,Return,State=#state{opts=Opts,last_tc_failed=LastTCFailed}) ->
+    IsVerbose = is_verbose(Opts),
+    case {IsVerbose, LastTCFailed} of
+        {false, _} ->
+            io:format(user, "~n", []);
+        {true, false} ->
+            io:format(user, "~n", []);
+        _Other ->
+            ok
+    end,
     {Return, State#state{suite=undefined, groups=[]}}.
 
 %% @doc Called before each init_per_group.
@@ -99,10 +121,34 @@ pre_init_per_testcase(_TC,Config,State) ->
     {Config, State}.
 
 %% @doc Called after each test case.
-post_end_per_testcase(TC,_Config,ok,State=#state{suite=Suite, groups=Groups}) ->
+post_end_per_testcase(TC,_Config,ok,State=#state{suite=Suite, groups=Groups, last_suite=LastSuite, opts=Opts, last_tc_failed=LastTCFailed}) ->
+    IsVerbose = is_verbose(Opts),
+    IsFirstInSuite = Suite =/= LastSuite,
+    case {IsVerbose, IsFirstInSuite, LastTCFailed} of
+        {_, true, _} ->
+            io:format(user, ": ", []);
+        {true, false, true} ->
+            io:format(user, "%%% ~p: ", [Suite]);
+        _Other ->
+            ok
+    end,
     ?OK(Suite, "~s", [format_path(TC,Groups)]),
-    {ok, State};
-post_end_per_testcase(TC,Config,Error,State=#state{suite=Suite, groups=Groups}) ->
+    {ok, State#state{last_suite = Suite, last_tc_failed=false}};
+post_end_per_testcase(TC,Config,Error,State=#state{suite=Suite, groups=Groups, opts=Opts, last_suite=LastSuite, last_tc_failed=LastTCFailed}) ->
+    IsVerbose = is_verbose(Opts),
+    IsFirstInSuite = Suite =/= LastSuite,
+    case {IsVerbose, IsFirstInSuite, LastTCFailed} of
+        {true, true, _} ->
+            io:format(user, " ==> ", []);
+        {true, false, false} ->
+            io:format(user, "~n%%% ~p ==> ", [Suite]);
+        {true, false, true} ->
+            io:format(user, "%%% ~p ==> ", [Suite]);
+        {false, true, _} ->
+            io:format(user, ": ", []);
+        _Other ->
+            ok
+    end,
     case lists:keyfind(tc_status, 1, Config) of
         {tc_status, ok} ->
             %% Test case passed, but we still ended in an error
@@ -111,7 +157,7 @@ post_end_per_testcase(TC,Config,Error,State=#state{suite=Suite, groups=Groups}) 
             %% Test case failed, in which case on_tc_fail already reports it
             ok
     end,
-    {Error, State}.
+    {Error, State#state{last_suite = Suite, last_tc_failed=true}}.
 
 %% @doc Called after post_init_per_suite, post_end_per_suite, post_init_per_group,
 %% post_end_per_group and post_end_per_testcase if the suite, group or test case failed.
@@ -129,11 +175,30 @@ on_tc_skip(Suite, {TC,_Group}, Reason, State=#state{groups=Groups, opts=Opts}) -
     State#state{suite=Suite};
 on_tc_skip(Suite, TC, Reason, State=#state{groups=Groups, opts=Opts}) ->
     skip(Suite, TC, Groups, Reason, Opts),
+    IsVerbose = is_verbose(Opts),
+    case {IsVerbose, TC} of
+        {false, end_per_suite} ->
+            % because post_end_per_suite is not called for a wholly-skipped suite
+            io:format(user, "~n", []);
+        _Other ->
+            ok
+    end,
     State#state{suite=Suite}.
 
 skip(Suite, TC, Groups, Reason, Opts) ->
-    Verbose = proplists:get_value(verbose, Opts, true),
-    ?SKIP(Suite, "~s", [format_path(TC,Groups)], Reason, Verbose).
+    IsVerbose = is_verbose(Opts),
+    case {IsVerbose, TC} of
+        % In non-verbose we don't print * for these two methods
+        {false, init_per_suite} ->
+            ok;
+        {false, end_per_suite} ->
+            ok;
+        _Other ->
+            ?SKIP(Suite, "~s", [format_path(TC,Groups)], Reason, is_verbose(Opts))
+    end.
+
+is_verbose(Opts) ->
+    proplists:get_value(verbose, Opts, true).
 
 %% @doc Called when a test case is skipped by either user action
 %% or due to an init function failing. (Pre-19.3)


### PR DESCRIPTION
I'd previously committed a version (released as `1.6.0`) that, while in a working condition, didn't fully address the issues I came to find when importing it into `erlang/rebar3` as a vendored app.

I hope to fix these shortcomings by adding a few more control variables and working around some issues presented by the fact that, when in "hook" mode Erlang calls your hook functions but also outputs to `stdout`.

Ref: https://github.com/erlang/rebar3/pull/2821