### PR TITLE
OTP-28 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ It will let you have both proper formatting and support for arbitrary
 configurations.
 
 ## Changelog
+
+1.6.1:
+- Cleaning up some code for OTP-28, mostly around type usage
+
 1.6.0:
 - Adding support for less verbose test skipping (thanks @paulo-ferraz-oliveira)
 

--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,11 @@
 
 {profiles, [
     {test, [
-        {deps, [{lager, "3.9.2"}]}
+        {deps, [{lager, "3.9.2"}]},
+        {erl_opts, [debug_info, nowarn_export_all]}
     ]}
+]}.
+
+{dialyzer, [
+    {warnings, [no_unknown]}
 ]}.

--- a/src/cth_readable.app.src
+++ b/src/cth_readable.app.src
@@ -1,6 +1,6 @@
 {application, cth_readable,
  [{description, "Common Test hooks for more readable logs"},
-  {vsn, "1.6.0"},
+  {vsn, "1.6.1"},
   {registered, [cth_readable_failonly, cth_readable_logger]},
   {applications,
    [kernel,

--- a/src/cth_readable.app.src
+++ b/src/cth_readable.app.src
@@ -6,6 +6,7 @@
    [kernel,
     stdlib,
     syntax_tools,
+    common_test,
     cf
    ]},
   {env,[]},

--- a/src/cth_readable_compact_shell.erl
+++ b/src/cth_readable_compact_shell.erl
@@ -5,29 +5,6 @@
 -define(FAILC, red).
 -define(SKIPC, magenta).
 
--define(OK(Suite, CasePat, CaseArgs),
-        ?CASE(Suite, CasePat, ?OKC, "OK", CaseArgs)).
--define(SKIP(Suite, CasePat, CaseArgs, Reason, Verbose),
-        ?STACK(Suite, CasePat, CaseArgs, Reason, ?SKIPC, "SKIPPED", Verbose)).
--define(FAIL(Suite, CasePat, CaseArgs, Reason),
-        ?STACK(Suite, CasePat, CaseArgs, Reason, ?FAILC, "FAILED")).
--define(STACK(Suite, CasePat, CaseArgs, Reason, Color, Label),
-        ?STACK(Suite, CasePat, CaseArgs, Reason, Color, Label, true)).
--define(STACK(Suite, CasePat, CaseArgs, Reason, Color, Label, Verbose),
-        begin
-          case Verbose of
-            true ->
-              ?CASE(Suite, CasePat, Color, Label, CaseArgs),
-               io:format(user, "%%% ~p ==> ~ts~n", [Suite,colorize(Color, maybe_eunit_format(Reason))]);
-            false ->
-              io:format(user, colorize(Color, "*"), [])
-          end
-        end).
--define(CASE(Suite, CasePat, Color, Res, Args),
-        case Res of
-            "OK" -> io:put_chars(user, colorize(Color, "."));
-            _ -> io:format(user, lists:flatten(["~n%%% ~p ==> ",CasePat,": ",colorize(Color, Res),"~n"]), [Suite | Args])
-        end).
 
 %% Callbacks
 -export([id/1]).
@@ -102,13 +79,13 @@ pre_init_per_testcase(_TC,Config,State) ->
 
 %% @doc Called after each test case.
 post_end_per_testcase(TC,_Config,ok,State=#state{suite=Suite, groups=Groups}) ->
-    ?OK(Suite, "~s", [format_path(TC,Groups)]),
+    format_ok(Suite, "~s", [format_path(TC,Groups)]),
     {ok, State};
 post_end_per_testcase(TC,Config,Error,State=#state{suite=Suite, groups=Groups}) ->
     case lists:keyfind(tc_status, 1, Config) of
         {tc_status, ok} ->
             %% Test case passed, but we still ended in an error
-            ?STACK(Suite, "~s", [format_path(TC,Groups)], Error, ?SKIPC, "end_per_testcase FAILED");
+            format_stack(Suite, "~s", [format_path(TC,Groups)], Error, ?SKIPC, "end_per_testcase FAILED");
         _ ->
             %% Test case failed, in which case on_tc_fail already reports it
             ok
@@ -118,10 +95,10 @@ post_end_per_testcase(TC,Config,Error,State=#state{suite=Suite, groups=Groups}) 
 %% @doc Called after post_init_per_suite, post_end_per_suite, post_init_per_group,
 %% post_end_per_group and post_end_per_testcase if the suite, group or test case failed.
 on_tc_fail({TC,_Group}, Reason, State=#state{suite=Suite, groups=Groups}) ->
-    ?FAIL(Suite, "~s", [format_path(TC,Groups)], Reason),
+    format_fail(Suite, "~s", [format_path(TC,Groups)], Reason),
     State;
 on_tc_fail(TC, Reason, State=#state{suite=Suite, groups=Groups}) ->
-    ?FAIL(Suite, "~s", [format_path(TC,Groups)], Reason),
+    format_fail(Suite, "~s", [format_path(TC,Groups)], Reason),
     State.
 
 %% @doc Called when a test case is skipped by either user action
@@ -135,17 +112,48 @@ on_tc_skip(Suite, TC, Reason, State=#state{groups=Groups, opts=Opts}) ->
 
 skip(Suite, TC, Groups, Reason, Opts) ->
     Verbose = proplists:get_value(verbose, Opts, true),
-    ?SKIP(Suite, "~s", [format_path(TC,Groups)], Reason, Verbose).
+    format_skip(Suite, "~s", [format_path(TC,Groups)], Reason, Verbose).
 
 %% @doc Called when a test case is skipped by either user action
 %% or due to an init function failing. (Pre-19.3)
 on_tc_skip({TC,Group}, Reason, State=#state{suite=Suite}) ->
-    ?SKIP(Suite, "~p (group ~p)", [TC, Group], Reason, true),
+    format_skip(Suite, "~p (group ~p)", [TC, Group], Reason, true),
     State;
 on_tc_skip(TC, Reason, State=#state{suite=Suite}) ->
-    ?SKIP(Suite, "~p", [TC], Reason, true),
+    format_skip(Suite, "~p", [TC], Reason, true),
     State.
 
 %% @doc Called when the scope of the CTH is done
 terminate(_State) ->
     ok.
+
+%%%%%%%%%%%%%%%
+%%% HELPERS %%%
+%%%%%%%%%%%%%%%
+
+format_ok(Suite, CasePat, CaseArgs) ->
+    format_case(Suite, CasePat, ?OKC, "OK", CaseArgs).
+
+format_skip(Suite, CasePat, CaseArgs, Reason, Verbose) ->
+    format_stack(Suite, CasePat, CaseArgs, Reason, ?SKIPC, "SKIPPED", Verbose).
+
+format_fail(Suite, CasePat, CaseArgs, Reason) ->
+    format_stack(Suite, CasePat, CaseArgs, Reason, ?FAILC, "FAILED").
+
+format_stack(Suite, CasePat, CaseArgs, Reason, Color, Label) ->
+    format_stack(Suite, CasePat, CaseArgs, Reason, Color, Label, true).
+
+format_stack(Suite, CasePat, CaseArgs, Reason, Color, Label, Verbose) ->
+    case Verbose of
+        true ->
+            format_case(Suite, CasePat, Color, Label, CaseArgs),
+            io:format(user, "%%% ~p ==> ~ts~n", [Suite,colorize(Color, maybe_eunit_format(Reason))]);
+        false ->
+            io:format(user, colorize(Color, "*"), [])
+    end.
+
+format_case(Suite, CasePat, Color, Res, Args) ->
+    case Res of
+        "OK" -> io:put_chars(user, colorize(Color, "."));
+        _ -> io:format(user, lists:flatten(["~n%%% ~p ==> ",CasePat,": ",colorize(Color, Res),"~n"]), [Suite | Args])
+    end.

--- a/src/cth_readable_shell.erl
+++ b/src/cth_readable_shell.erl
@@ -5,30 +5,6 @@
 -define(FAILC, red).
 -define(SKIPC, magenta).
 
--define(OK(Suite, CasePat, CaseArgs),
-        ?CASE(Suite, CasePat, ?OKC, "OK", CaseArgs)).
--define(SKIP(Suite, CasePat, CaseArgs, Reason, Verbose),
-        ?STACK(Suite, CasePat, CaseArgs, Reason, ?SKIPC, "SKIPPED", Verbose)).
--define(FAIL(Suite, CasePat, CaseArgs, Reason),
-        ?STACK(Suite, CasePat, CaseArgs, Reason, ?FAILC, "FAILED")).
--define(STACK(Suite, CasePat, CaseArgs, Reason, Color, Label),
-        ?STACK(Suite, CasePat, CaseArgs, Reason, Color, Label, true)).
--define(STACK(Suite, CasePat, CaseArgs, Reason, Color, Label, Verbose),
-        begin
-          case Verbose of
-            true ->
-              ?CASE(Suite, CasePat, Color, Label, CaseArgs),
-             io:format(user, "%%% ~p ==> ~ts~n", [Suite,colorize(Color, maybe_eunit_format(Reason))]);
-            false ->
-              io:format(user, colorize(Color, "*"), [])
-          end
-        end).
--define(CASE(Suite, CasePat, Color, Res, Args),
-        case Res of
-            "OK" -> io:put_chars(user, colorize(Color, "."));
-            _ -> io:format(user, lists:flatten(["~n%%% ~p ==> ",CasePat,": ",colorize(Color, Res),"~n"]), [Suite | Args])
-        end).
-
 %% Callbacks
 -export([id/1]).
 -export([init/2]).
@@ -100,13 +76,13 @@ pre_init_per_testcase(_TC,Config,State) ->
 
 %% @doc Called after each test case.
 post_end_per_testcase(TC,_Config,ok,State=#state{suite=Suite, groups=Groups}) ->
-    ?OK(Suite, "~s", [format_path(TC,Groups)]),
+    format_ok(Suite, "~s", [format_path(TC,Groups)]),
     {ok, State};
 post_end_per_testcase(TC,Config,Error,State=#state{suite=Suite, groups=Groups}) ->
     case lists:keyfind(tc_status, 1, Config) of
         {tc_status, ok} ->
             %% Test case passed, but we still ended in an error
-            ?STACK(Suite, "~s", [format_path(TC,Groups)], Error, ?SKIPC, "end_per_testcase FAILED");
+            format_stack(Suite, "~s", [format_path(TC,Groups)], Error, ?SKIPC, "end_per_testcase FAILED");
         _ ->
             %% Test case failed, in which case on_tc_fail already reports it
             ok
@@ -116,10 +92,10 @@ post_end_per_testcase(TC,Config,Error,State=#state{suite=Suite, groups=Groups}) 
 %% @doc Called after post_init_per_suite, post_end_per_suite, post_init_per_group,
 %% post_end_per_group and post_end_per_testcase if the suite, group or test case failed.
 on_tc_fail({TC,_Group}, Reason, State=#state{suite=Suite, groups=Groups}) ->
-    ?FAIL(Suite, "~s", [format_path(TC,Groups)], Reason),
+    format_fail(Suite, "~s", [format_path(TC,Groups)], Reason),
     State;
 on_tc_fail(TC, Reason, State=#state{suite=Suite, groups=Groups}) ->
-    ?FAIL(Suite, "~s", [format_path(TC,Groups)], Reason),
+    format_fail(Suite, "~s", [format_path(TC,Groups)], Reason),
     State.
 
 %% @doc Called when a test case is skipped by either user action
@@ -133,17 +109,47 @@ on_tc_skip(Suite, TC, Reason, State=#state{groups=Groups, opts=Opts}) ->
 
 skip(Suite, TC, Groups, Reason, Opts) ->
     Verbose = proplists:get_value(verbose, Opts, true),
-    ?SKIP(Suite, "~s", [format_path(TC,Groups)], Reason, Verbose).
+    format_skip(Suite, "~s", [format_path(TC,Groups)], Reason, Verbose).
 
 %% @doc Called when a test case is skipped by either user action
 %% or due to an init function failing. (Pre-19.3)
 on_tc_skip({TC,Group}, Reason, State=#state{suite=Suite}) ->
-    ?SKIP(Suite, "~p (group ~p)", [TC, Group], Reason, true),
+    format_skip(Suite, "~p (group ~p)", [TC, Group], Reason, true),
     State;
 on_tc_skip(TC, Reason, State=#state{suite=Suite}) ->
-    ?SKIP(Suite, "~p", [TC], Reason, true),
+    format_skip(Suite, "~p", [TC], Reason, true),
     State.
 
 %% @doc Called when the scope of the CTH is done
 terminate(_State) ->
     ok.
+
+%%%%%%%%%%%%%%%%
+%%% Helpers %%%
+%%%%%%%%%%%%%%%%
+format_ok(Suite, CasePat, CaseArgs) ->
+    format_case(Suite, CasePat, ?OKC, "OK", CaseArgs).
+
+format_skip(Suite, CasePat, CaseArgs, Reason, Verbose) ->
+    format_stack(Suite, CasePat, CaseArgs, Reason, ?SKIPC, "SKIPPED", Verbose).
+
+format_fail(Suite, CasePat, CaseArgs, Reason) ->
+    format_stack(Suite, CasePat, CaseArgs, Reason, ?FAILC, "FAILED").
+
+format_case(Suite, CasePat, Color, Res, Args) ->
+    case Res of
+        "OK" -> io:put_chars(user, colorize(Color, "."));
+        _ -> io:format(user, lists:flatten(["~n%%% ~p ==> ",CasePat,": ",colorize(Color, Res),"~n"]), [Suite | Args])
+    end.
+
+format_stack(Suite, CasePat, CaseArgs, Reason, Color, Label) ->
+    format_stack(Suite, CasePat, CaseArgs, Reason, Color, Label, true).
+
+format_stack(Suite, CasePat, CaseArgs, Reason, Color, Label, Verbose) ->
+    case Verbose of
+        true ->
+            format_case(Suite, CasePat, Color, Label, CaseArgs),
+            io:format(user, "%%% ~p ==> ~ts~n", [Suite,colorize(Color, maybe_eunit_format(Reason))]);
+        false ->
+            io:format(user, colorize(Color, "*"), [])
+    end.


### PR DESCRIPTION
- Fixes some bad types
- Deprecates old workarounds for pre-release versions
- De-inline macros as functions to avoid an over-eager Dialyzer analysis